### PR TITLE
OSX: Fix Hostname.pm for getting the ComputerName

### DIFF
--- a/lib/FusionInventory/Agent/Task/Inventory/MacOS/Hostname.pm
+++ b/lib/FusionInventory/Agent/Task/Inventory/MacOS/Hostname.pm
@@ -16,7 +16,7 @@ sub doInventory {
     my $inventory = $params{inventory};
     my $logger    = $params{logger};
 
-    my $infos = getSystemProfilerInfos(type => 'SPApplicationsDataType', logger => $logger);
+    my $infos = getSystemProfilerInfos(type => 'SPSoftwareDataType', logger => $logger);
 
     my $hostname =
         $infos->{'Software'}->{'System Software Overview'}->{'Computer Name'};


### PR DESCRIPTION
The ComputerName entry is available in SPSoftwareDataType only, SPApplicationsDataType does't have this entry, which was leading to return an empty value.